### PR TITLE
add destination namespace to telemetry

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -67,12 +67,13 @@ type LearningParametrizedPaths struct {
 
 type (
 	SCNTelemetry struct {
-		RequestID          string       `json:"request_id"`
-		Scheme             string       `json:"scheme"`
-		DestinationAddress string       `json:"destination_address"`
-		SourceAddress      string       `json:"source_address"`
-		SCNTRequest        SCNTRequest  `json:"scnt_request"`
-		SCNTResponse       SCNTResponse `json:"scnt_response"`
+		RequestID            string       `json:"request_id"`
+		Scheme               string       `json:"scheme"`
+		DestinationAddress   string       `json:"destination_address"`
+		DestinationNamespace string       `json:"destination_namespace"`
+		SourceAddress        string       `json:"source_address"`
+		SCNTRequest          SCNTRequest  `json:"scnt_request"`
+		SCNTResponse         SCNTResponse `json:"scnt_response"`
 	}
 
 	SCNTRequest struct {


### PR DESCRIPTION
Align telemetry with struct of wasm filter to contain also destinationNamespace
In the next step we will need to remove this structure completely and use only models.Telemetry