### PR TITLE
feat: Peel out OAuth2 scopes from Bearer JWTs if present.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.0
 	github.com/go-openapi/swag v0.19.15
 	github.com/go-openapi/validate v0.20.3
+	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/onsi/gomega v1.14.0 // indirect
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/V
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/spec/constans.go
+++ b/pkg/spec/constans.go
@@ -58,3 +58,8 @@ const (
 	mediaTypeApplicationForm    = "application/x-www-form-urlencoded"
 	mediaTypeMultipartFormData  = "multipart/form-data"
 )
+
+const (
+	apiKeyInHeader = "header"
+	apiKeyInQuery  = "query"
+)

--- a/pkg/spec/diff_test.go
+++ b/pkg/spec/diff_test.go
@@ -75,13 +75,7 @@ var DataCombined = &HTTPInteractionData{
 	statusCode: 200,
 }
 
-var DiffOAuthScopes []string = []string{"superadmin", "write:all_your_base"}
-
-func init() {
-	// Update auth after init
-	bearerToken := generateDefaultOAuthToken(DiffOAuthScopes)
-	DataWithAuth.ReqHeaders[authorizationTypeHeaderName] = BearerAuthPrefix + bearerToken
-}
+var DiffOAuthScopes = []string{"superadmin", "write:all_your_base"}
 
 func createTelemetry(reqID, method, path, host, statusCode string, reqBody, respBody string) *Telemetry {
 	return &Telemetry{
@@ -121,7 +115,7 @@ func createTelemetry(reqID, method, path, host, statusCode string, reqBody, resp
 }
 
 func createTelemetryWithSecurity(reqID, method, path, host, statusCode string, reqBody, respBody string) *Telemetry {
-	bearerToken := generateDefaultOAuthToken(DiffOAuthScopes)
+	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScopes)
 
 	telemetry := createTelemetry(reqID, method, path, host, statusCode, reqBody, respBody)
 	telemetry.Request.Common.Headers = append(telemetry.Request.Common.Headers, &Header{
@@ -135,6 +129,8 @@ func TestSpec_DiffTelemetry_Reconstructed(t *testing.T) {
 	reqID := "req-id"
 	reqUUID := uuid.NewV5(uuid.Nil, reqID)
 	specUUID := uuid.NewV5(uuid.Nil, "spec-id")
+	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScopes)
+	DataWithAuth.ReqHeaders[authorizationTypeHeaderName] = BearerAuthPrefix + bearerToken
 	type fields struct {
 		ID               uuid.UUID
 		ApprovedSpec     *ApprovedSpec
@@ -369,6 +365,8 @@ func TestSpec_DiffTelemetry_Provided(t *testing.T) {
 	reqID := "req-id"
 	reqUUID := uuid.NewV5(uuid.Nil, reqID)
 	specUUID := uuid.NewV5(uuid.Nil, "spec-id")
+	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScopes)
+	DataWithAuth.ReqHeaders[authorizationTypeHeaderName] = BearerAuthPrefix + bearerToken
 	type fields struct {
 		ID               uuid.UUID
 		ProvidedSpec     *ProvidedSpec

--- a/pkg/spec/diff_test.go
+++ b/pkg/spec/diff_test.go
@@ -75,11 +75,11 @@ var DataCombined = &HTTPInteractionData{
 	statusCode: 200,
 }
 
-const DiffOAuthScope string = "superadmin write:all_your_base"
+var DiffOAuthScopes []string = []string{"superadmin", "write:all_your_base"}
 
 func init() {
 	// Update auth after init
-	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScope)
+	bearerToken := generateDefaultOAuthToken(DiffOAuthScopes)
 	DataWithAuth.ReqHeaders[authorizationTypeHeaderName] = BearerAuthPrefix + bearerToken
 }
 
@@ -121,7 +121,7 @@ func createTelemetry(reqID, method, path, host, statusCode string, reqBody, resp
 }
 
 func createTelemetryWithSecurity(reqID, method, path, host, statusCode string, reqBody, respBody string) *Telemetry {
-	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScope)
+	bearerToken := generateDefaultOAuthToken(DiffOAuthScopes)
 
 	telemetry := createTelemetry(reqID, method, path, host, statusCode, reqBody, respBody)
 	telemetry.Request.Common.Headers = append(telemetry.Request.Common.Headers, &Header{

--- a/pkg/spec/diff_test.go
+++ b/pkg/spec/diff_test.go
@@ -43,7 +43,7 @@ var DataWithAuth = &HTTPInteractionData{
 	RespBody: res1,
 	ReqHeaders: map[string]string{
 		contentTypeHeaderName:       mediaTypeApplicationJSON,
-		authorizationTypeHeaderName: BearerAuthPrefix + "token",
+		authorizationTypeHeaderName: BearerAuthPrefix,
 	},
 	RespHeaders: map[string]string{
 		contentTypeHeaderName: mediaTypeApplicationJSON,
@@ -73,6 +73,14 @@ var DataCombined = &HTTPInteractionData{
 		contentTypeHeaderName: mediaTypeApplicationJSON,
 	},
 	statusCode: 200,
+}
+
+const DiffOAuthScope string = "superadmin write:all_your_base"
+
+func init() {
+	// Update auth after init
+	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScope)
+	DataWithAuth.ReqHeaders[authorizationTypeHeaderName] = BearerAuthPrefix + bearerToken
 }
 
 func createTelemetry(reqID, method, path, host, statusCode string, reqBody, respBody string) *Telemetry {
@@ -113,10 +121,12 @@ func createTelemetry(reqID, method, path, host, statusCode string, reqBody, resp
 }
 
 func createTelemetryWithSecurity(reqID, method, path, host, statusCode string, reqBody, respBody string) *Telemetry {
+	bearerToken, _ := generateDefaultOAuthToken(DiffOAuthScope)
+
 	telemetry := createTelemetry(reqID, method, path, host, statusCode, reqBody, respBody)
 	telemetry.Request.Common.Headers = append(telemetry.Request.Common.Headers, &Header{
 		Key:   authorizationTypeHeaderName,
-		Value: BearerAuthPrefix + "token",
+		Value: BearerAuthPrefix + bearerToken,
 	})
 	return telemetry
 }

--- a/pkg/spec/form.go
+++ b/pkg/spec/form.go
@@ -39,14 +39,20 @@ func addApplicationFormParams(operation *spec.Operation, sd spec.SecurityDefinit
 
 	for key, values := range values {
 		if key == AccessTokenParamKey {
-			ok := false
-			if len(values) > 0 {
-				operation, ok = handleAuthJWT(operation, values[len(values)-1])
+			// Use scheme as security definition name. For OAuth, we should consider checking
+			// supported scopes to allow multiple defs.
+			sdName := OAuth2SecurityDefinitionKey
+
+			if len(values) > 1 {
+				// RFC 6750 does not prohibit multiple tokens, but we do not know whether
+				// they would be AND or OR so we just pick the latest.
+				log.Warnf("Found %v tokens in form parameters, using only the last", len(values))
+				values = values[len(values)-1:]
 			}
-			if !ok {
-				operation = addSecurity(operation, OAuth2SecurityDefinitionKey)
-			}
-			sd = updateSecurityDefinitions(sd, OAuth2SecurityDefinitionKey)
+
+			var scheme *spec.SecurityScheme
+			operation, scheme = generateAuthBearerScheme(operation, values[0], sdName)
+			sd = updateSecurityDefinitions(sd, sdName, scheme)
 		} else {
 			operation.AddParam(populateParam(spec.FormDataParam(key), values, true))
 		}

--- a/pkg/spec/form.go
+++ b/pkg/spec/form.go
@@ -39,7 +39,13 @@ func addApplicationFormParams(operation *spec.Operation, sd spec.SecurityDefinit
 
 	for key, values := range values {
 		if key == AccessTokenParamKey {
-			operation = addSecurity(operation, OAuth2SecurityDefinitionKey)
+			ok := false
+			if len(values) > 0 {
+				operation, ok = handleAuthJWT(operation, values[len(values)-1])
+			}
+			if !ok {
+				operation = addSecurity(operation, OAuth2SecurityDefinitionKey)
+			}
 			sd = updateSecurityDefinitions(sd, OAuth2SecurityDefinitionKey)
 		} else {
 			operation.AddParam(populateParam(spec.FormDataParam(key), values, true))

--- a/pkg/spec/operation.go
+++ b/pkg/spec/operation.go
@@ -240,23 +240,45 @@ func (o *OperationGenerator) GenerateSpecOperation(data *HTTPInteractionData, se
 	}
 
 	for key, value := range data.ReqHeaders {
-		if strings.ToLower(key) == authorizationTypeHeaderName {
+		lowerKey := strings.ToLower(key)
+		if lowerKey == authorizationTypeHeaderName {
 			operation, securityDefinitions = handleAuthReqHeader(operation, securityDefinitions, value)
+		} else if ApiKeyNames[lowerKey] {
+			sdName := APIKeyAuthSecurityDefinitionKey
+			operation = addSecurity(operation, sdName)
+			scheme := spec.APIKeyAuth(key, apiKeyInHeader)
+			securityDefinitions = updateSecurityDefinitions(securityDefinitions, sdName, scheme)
 		} else {
 			operation = o.addHeaderParam(operation, key, value)
 		}
 	}
 
 	for key, values := range data.QueryParams {
-		if key == AccessTokenParamKey {
-			ok := false
-			if len(values) > 0 {
-				operation, ok = handleAuthJWT(operation, values[len(values)-1])
+		lowerKey := strings.ToLower(key)
+		if lowerKey == AccessTokenParamKey {
+			// Use scheme as security definition name
+			sdName := OAuth2SecurityDefinitionKey
+			var scheme *spec.SecurityScheme
+
+			if hasSecurity(operation, sdName) {
+				// RFC 6750 states multiple methods (form, uri query, header) cannot be used.
+				log.Errorf("OAuth tokens supplied with multiple methods, ignoring URI query param: %v", key)
+				continue
 			}
-			if !ok {
-				operation = addSecurity(operation, OAuth2SecurityDefinitionKey)
+			if len(values) > 1 {
+				// RFC 6750 does not prohibit multiple tokens, but we do not know whether
+				// they would be AND or OR so we just pick the latest.
+				log.Warnf("Found %v tokens in query parameters, using only the last", len(values))
+				values = values[len(values)-1:]
 			}
-			securityDefinitions = updateSecurityDefinitions(securityDefinitions, OAuth2SecurityDefinitionKey)
+
+			operation, scheme = generateAuthBearerScheme(operation, values[0], sdName)
+			securityDefinitions = updateSecurityDefinitions(securityDefinitions, sdName, scheme)
+		} else if ApiKeyNames[lowerKey] {
+			sdName := APIKeyAuthSecurityDefinitionKey
+			operation = addSecurity(operation, sdName)
+			scheme := spec.APIKeyAuth(key, apiKeyInQuery)
+			securityDefinitions = updateSecurityDefinitions(securityDefinitions, sdName, scheme)
 		} else {
 			operation = addQueryParam(operation, key, values)
 		}
@@ -319,37 +341,60 @@ func CloneOperation(op *spec.Operation) (*spec.Operation, error) {
 	return &out, nil
 }
 
-func handleAuthJWT(operation *spec.Operation, bearerToken string) (*spec.Operation, bool) {
+func generateAuthBearerScheme(operation *spec.Operation, bearerToken string, sdName string) (*spec.Operation, *spec.SecurityScheme) {
 	// Parse the claims without validating (since we don't want to bother downloading a key)
 	parser := jwt.Parser{}
+	// we can't know the flow type (implicit, password, application or accessCode) so we choose accessCode for now
+	scheme := spec.OAuth2AccessToken(authorizationURL, tknURL)
+
+	if len(bearerToken) == 0 {
+		log.Warnf("authZ token provided with no value, assuming OAuth required anyway")
+		return addSecurity(operation, sdName), scheme
+	}
+
 	token, _, err := parser.ParseUnverified(bearerToken, jwt.MapClaims{})
 	if err != nil {
-		return operation, false
+		// Note: it is not a JWT so we just mark generic OAuth
+		log.Warnf("authZ token is not a JWT, assuming OAuth required anyway")
+		return addSecurity(operation, sdName), scheme
 	}
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return operation, false
+		// Claims are unintelligible so we just mark generic OAuth
+		log.Warnf("authZ token had unintelligble claims, assuming OAuth required anyway")
+		return addSecurity(operation, sdName), scheme
 	}
+	scopes := []string{}
 	if scope, ok := claims["scope"]; ok {
-		scopes := strings.Split(scope.(string), " ")
-		log.Debugf("Found scopes: %v", scopes)
-		return addSecurity(operation, OAuth2SecurityDefinitionKey, scopes...), true
+		scopes = strings.Split(scope.(string), " ")
+		log.Debugf("found OAuth token scopes: %v", scopes)
+	} else {
+		log.Warnf("no scopes defined in this token")
 	}
-	log.Warnf("No scope defined in this token")
-	return addSecurity(operation, OAuth2SecurityDefinitionKey, []string{}...), true
+	updateSecuritySchemeScopes(scheme, scopes, []string{})
+	return addSecurity(operation, sdName, scopes...), scheme
 }
 
 func handleAuthReqHeader(operation *spec.Operation, sd spec.SecurityDefinitions, value string) (*spec.Operation, spec.SecurityDefinitions) {
 	if strings.HasPrefix(value, BasicAuthPrefix) {
-		operation = addSecurity(operation, BasicAuthSecurityDefinitionKey)
-		sd = updateSecurityDefinitions(sd, BasicAuthSecurityDefinitionKey)
+		// Use scheme as security definition name
+		sdName := BasicAuthSecurityDefinitionKey
+		operation = addSecurity(operation, sdName)
+		sd = updateSecurityDefinitions(sd, sdName, spec.BasicAuth())
 	} else if strings.HasPrefix(value, BearerAuthPrefix) {
-		tokenString := strings.TrimPrefix(value, BearerAuthPrefix)
-		if len(tokenString) > 0 {
-			// Note: it might not be a JWT so we don't update in that case.
-			operation, _ = handleAuthJWT(operation, tokenString)
-			sd = updateSecurityDefinitions(sd, OAuth2SecurityDefinitionKey)
+		// Use scheme as security definition name. For OAuth, we should consider checking
+		// supported scopes to allow multiple defs.
+		sdName := OAuth2SecurityDefinitionKey
+
+		if hasSecurity(operation, sdName) {
+			// RFC 6750 states multiple methods (form, uri query, header) cannot be used.
+			log.Error("OAuth tokens supplied with multiple methods, ignoring header")
+			return operation, sd
 		}
+
+		var scheme *spec.SecurityScheme
+		operation, scheme = generateAuthBearerScheme(operation, strings.TrimPrefix(value, BearerAuthPrefix), sdName)
+		sd = updateSecurityDefinitions(sd, sdName, scheme)
 	} else {
 		log.Warnf("ignoring unknown authorization header value (%v)", value)
 	}
@@ -360,11 +405,19 @@ func addSecurity(op *spec.Operation, name string, scopes ...string) *spec.Operat
 	// https://swagger.io/docs/specification/2-0/authentication/
 	// We will treat multiple authentication types as an OR
 	// (Security schemes combined via OR are alternatives – any one can be used in the given context)
-
 	if len(scopes) > 0 {
 		return op.SecuredWith(name, scopes...)
 	} else {
 		// We must use an empty array as the scopes, otherwise it will create invalid swagger
 		return op.SecuredWith(name, []string{}...)
 	}
+}
+
+func hasSecurity(op *spec.Operation, name string) bool {
+	for _, securityScheme := range op.Security {
+		if _, ok := securityScheme[name]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/spec/operation.go
+++ b/pkg/spec/operation.go
@@ -243,7 +243,7 @@ func (o *OperationGenerator) GenerateSpecOperation(data *HTTPInteractionData, se
 		lowerKey := strings.ToLower(key)
 		if lowerKey == authorizationTypeHeaderName {
 			operation, securityDefinitions = handleAuthReqHeader(operation, securityDefinitions, value)
-		} else if ApiKeyNames[lowerKey] {
+		} else if APIKeyNames[lowerKey] {
 			sdName := APIKeyAuthSecurityDefinitionKey
 			operation = addSecurity(operation, sdName)
 			scheme := spec.APIKeyAuth(key, apiKeyInHeader)
@@ -274,7 +274,7 @@ func (o *OperationGenerator) GenerateSpecOperation(data *HTTPInteractionData, se
 
 			operation, scheme = generateAuthBearerScheme(operation, values[0], sdName)
 			securityDefinitions = updateSecurityDefinitions(securityDefinitions, sdName, scheme)
-		} else if ApiKeyNames[lowerKey] {
+		} else if APIKeyNames[lowerKey] {
 			sdName := APIKeyAuthSecurityDefinitionKey
 			operation = addSecurity(operation, sdName)
 			scheme := spec.APIKeyAuth(key, apiKeyInQuery)

--- a/pkg/spec/operation.go
+++ b/pkg/spec/operation.go
@@ -361,10 +361,10 @@ func addSecurity(op *spec.Operation, name string, scopes ...string) *spec.Operat
 	// We will treat multiple authentication types as an OR
 	// (Security schemes combined via OR are alternatives – any one can be used in the given context)
 
-	// We must use an empty array as the scopes, otherwise it will create invalid swagger
 	if len(scopes) > 0 {
 		return op.SecuredWith(name, scopes...)
 	} else {
+		// We must use an empty array as the scopes, otherwise it will create invalid swagger
 		return op.SecuredWith(name, []string{}...)
 	}
 }

--- a/pkg/spec/operation_test.go
+++ b/pkg/spec/operation_test.go
@@ -43,7 +43,7 @@ var defaultOAuth2Scopes []string = []string{"admin", "write:pets"}
 var defaultOAuth2BearerToken string = ""
 var defaultOAuth2JSON string = ""
 var defaultOAuthSecurityScheme *spec.SecurityScheme = nil
-var defaultApiKeyHeaderName = ""
+var defaultAPIKeyHeaderName = ""
 
 func init() {
 	defaultOAuth2BearerToken = generateDefaultOAuthToken(defaultOAuth2Scopes)
@@ -57,15 +57,14 @@ func init() {
 
 	defaultOAuthSecurityScheme = updateSecuritySchemeScopes(spec.OAuth2AccessToken(authorizationURL, tknURL), defaultOAuth2Scopes, []string{})
 
-	for key := range ApiKeyNames {
-		defaultApiKeyHeaderName = key
+	for key := range APIKeyNames {
+		defaultAPIKeyHeaderName = key
 		break
 	}
 }
 
 func generateDefaultOAuthToken(scopes []string) string {
 	mySigningKey := []byte("AllYourBase")
-	var err error = nil
 
 	var defaultOAuth2Claims jwt.Claims = OAuth2Claims{
 		strings.Join(scopes, " "),
@@ -264,7 +263,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					RespBody: cvssBody,
 					ReqHeaders: map[string]string{
 						contentTypeHeaderName:   mediaTypeApplicationJSON,
-						defaultApiKeyHeaderName: "mybogusapikey",
+						defaultAPIKeyHeaderName: "mybogusapikey",
 					},
 					RespHeaders: map[string]string{
 						contentTypeHeaderName: mediaTypeApplicationJSON,
@@ -274,7 +273,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 			},
 			want: "{\"security\":[{\"ApiKeyAuth\":[]}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
 			expectedSd: spec.SecurityDefinitions{
-				APIKeyAuthSecurityDefinitionKey: spec.APIKeyAuth(defaultApiKeyHeaderName, apiKeyInHeader),
+				APIKeyAuthSecurityDefinitionKey: spec.APIKeyAuth(defaultAPIKeyHeaderName, apiKeyInHeader),
 			},
 			wantErr: false,
 		},
@@ -290,13 +289,13 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					RespHeaders: map[string]string{
 						contentTypeHeaderName: mediaTypeApplicationJSON,
 					},
-					QueryParams: generateQueryParams(t, defaultApiKeyHeaderName+"=mybogusapikey"),
+					QueryParams: generateQueryParams(t, defaultAPIKeyHeaderName+"=mybogusapikey"),
 					statusCode:  200,
 				},
 			},
 			want: "{\"security\":[{\"ApiKeyAuth\":[]}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
 			expectedSd: spec.SecurityDefinitions{
-				APIKeyAuthSecurityDefinitionKey: spec.APIKeyAuth(defaultApiKeyHeaderName, apiKeyInQuery),
+				APIKeyAuthSecurityDefinitionKey: spec.APIKeyAuth(defaultAPIKeyHeaderName, apiKeyInQuery),
 			},
 			wantErr: false,
 		},

--- a/pkg/spec/operation_test.go
+++ b/pkg/spec/operation_test.go
@@ -19,9 +19,13 @@ import (
 	"encoding/json"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/spec"
+	"github.com/golang-jwt/jwt/v4"
+	log "github.com/sirupsen/logrus"
 	"github.com/yudai/gojsondiff"
 	"gotest.tools/assert"
 )
@@ -34,6 +38,60 @@ var agentStatusBody = `{"active":true,
 "version":"1.147.1"}`
 
 var cvssBody = `{"cvss":[{"score":7.8,"vector":"AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H","version":"3"}]}`
+
+var defaultOAuth2BearerToken string = ""
+var defaultOAuth2Scopes []string = nil
+var defaultOAuth2JSON string = ""
+
+func init() {
+	defaultOAuth2BearerToken, defaultOAuth2Scopes = generateDefaultOAuthToken("admin write:pets")
+
+	encoded, err := json.Marshal(defaultOAuth2Scopes)
+	if err != nil {
+		log.Errorf("Cannot encode token scopes: %v", defaultOAuth2Scopes)
+	} else {
+		defaultOAuth2JSON = string(encoded)
+	}
+}
+
+func generateDefaultOAuthToken(scope string) (string, []string) {
+	mySigningKey := []byte("AllYourBase")
+	var err error = nil
+
+	var defaultOAuth2Claims jwt.Claims = OAuth2Claims{
+		scope,
+		jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+			Issuer:    "test",
+			Subject:   "somebody",
+			Audience:  []string{"somebody_else"},
+		},
+	}
+	var defaultScopes []string = []string{}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, defaultOAuth2Claims)
+	bearerToken, err := token.SignedString(mySigningKey)
+
+	if err != nil {
+		log.Errorf("Failed to create default OAuth2 Bearer Token: %v", err)
+		return bearerToken, defaultScopes
+	}
+
+	token, err = jwt.Parse(bearerToken, func(token *jwt.Token) (interface{}, error) {
+		return mySigningKey, nil
+	})
+
+	// Convert claims to scopes
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
+		if scopes, ok := claims["scope"]; ok {
+			defaultScopes = strings.Split(scopes.(string), " ")
+		}
+	}
+
+	return bearerToken, defaultScopes
+}
 
 func generateQueryParams(t *testing.T, query string) url.Values {
 	t.Helper()
@@ -121,7 +179,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					RespBody: cvssBody,
 					ReqHeaders: map[string]string{
 						contentTypeHeaderName:       mediaTypeApplicationJSON,
-						authorizationTypeHeaderName: BearerAuthPrefix + "=token",
+						authorizationTypeHeaderName: BearerAuthPrefix + defaultOAuth2BearerToken,
 					},
 					RespHeaders: map[string]string{
 						contentTypeHeaderName: mediaTypeApplicationJSON,
@@ -129,7 +187,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					statusCode: 200,
 				},
 			},
-			want: "{\"security\":[{\"OAuth2\":[]}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
+			want: "{\"security\":[{\"OAuth2\":" + defaultOAuth2JSON + "}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
 			expectedSd: spec.SecurityDefinitions{
 				OAuth2SecurityDefinitionKey: spec.OAuth2AccessToken(authorizationURL, tknURL),
 			},
@@ -147,11 +205,11 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					RespHeaders: map[string]string{
 						contentTypeHeaderName: mediaTypeApplicationJSON,
 					},
-					QueryParams: generateQueryParams(t, AccessTokenParamKey+"=token"),
+					QueryParams: generateQueryParams(t, AccessTokenParamKey+"="+defaultOAuth2BearerToken),
 					statusCode:  200,
 				},
 			},
-			want: "{\"security\":[{\"OAuth2\":[]}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
+			want: "{\"security\":[{\"OAuth2\":" + defaultOAuth2JSON + "}],\"consumes\":[\"application/json\"],\"produces\":[\"application/json\"],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"active\":{\"type\":\"boolean\"},\"certificateVersion\":{\"type\":\"string\",\"format\":\"uuid\"},\"controllerInstanceInfo\":{\"type\":\"object\",\"properties\":{\"replicaId\":{\"type\":\"string\"}}},\"policyAndAppVersion\":{\"type\":\"integer\",\"format\":\"int64\"},\"statusCodes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"version\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
 			expectedSd: spec.SecurityDefinitions{
 				OAuth2SecurityDefinitionKey: spec.OAuth2AccessToken(authorizationURL, tknURL),
 			},
@@ -161,7 +219,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 			name: "OAuth 2.0 Form-Encoded Body Parameter",
 			args: args{
 				data: &HTTPInteractionData{
-					ReqBody:  AccessTokenParamKey + "=token&key=val",
+					ReqBody:  AccessTokenParamKey + "=" + defaultOAuth2BearerToken + "&key=val",
 					RespBody: cvssBody,
 					ReqHeaders: map[string]string{
 						contentTypeHeaderName: mediaTypeApplicationForm,
@@ -172,7 +230,7 @@ func TestGenerateSpecOperation1(t *testing.T) {
 					statusCode: 200,
 				},
 			},
-			want: "{\"security\":[{\"OAuth2\":[]}],\"consumes\":[\"application/x-www-form-urlencoded\"],\"produces\":[\"application/json\"],\"parameters\":[{\"type\":\"string\",\"name\":\"key\",\"in\":\"formData\"}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
+			want: "{\"security\":[{\"OAuth2\":" + defaultOAuth2JSON + "}],\"consumes\":[\"application/x-www-form-urlencoded\"],\"produces\":[\"application/json\"],\"parameters\":[{\"type\":\"string\",\"name\":\"key\",\"in\":\"formData\"}],\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"type\":\"object\",\"properties\":{\"cvss\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"format\":\"double\"},\"vector\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"}}}}}}},\"default\":{\"description\":\"Default Response\",\"schema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}}}}",
 			expectedSd: spec.SecurityDefinitions{
 				OAuth2SecurityDefinitionKey: spec.OAuth2AccessToken(authorizationURL, tknURL),
 			},
@@ -406,9 +464,9 @@ func Test_handleAuthReqHeader(t *testing.T) {
 			args: args{
 				operation: spec.NewOperation(""),
 				sd:        map[string]*spec.SecurityScheme{},
-				value:     BearerAuthPrefix + "token",
+				value:     BearerAuthPrefix + defaultOAuth2BearerToken,
 			},
-			wantOp: spec.NewOperation("").SecuredWith(OAuth2SecurityDefinitionKey, []string{}...),
+			wantOp: spec.NewOperation("").SecuredWith(OAuth2SecurityDefinitionKey, defaultOAuth2Scopes...),
 			wantSd: spec.SecurityDefinitions{
 				OAuth2SecurityDefinitionKey: spec.OAuth2AccessToken(authorizationURL, tknURL),
 			},

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -40,14 +40,13 @@ const (
 	authorizationURL = "https://example.com/oauth/authorize"
 )
 
-var (
-	// TODO: This should be runtime configurable, of course.
-	// Note: keys should be lower case.
-	APIKeyNames = map[string]bool{
-		"key":     true, // Google
-		"api_key": true,
-	}
-)
+// APIKeyNames is set of names of headers or query params defining API keys.
+// This should be runtime configurable, of course.
+// Note: keys should be lower case.
+var APIKeyNames = map[string]bool{
+	"key":     true, // Google
+	"api_key": true,
+}
 
 func updateSecurityDefinitionsFromOperation(sd spec.SecurityDefinitions, op *spec.Operation) spec.SecurityDefinitions {
 	if op == nil {

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -17,8 +17,14 @@ package spec
 
 import (
 	"github.com/go-openapi/spec"
+	"github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
 )
+
+type OAuth2Claims struct {
+	Scope string `json:"scope"`
+	jwt.RegisteredClaims
+}
 
 const (
 	BasicAuthSecurityDefinitionKey  = "BasicAuth"

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -42,8 +42,8 @@ const (
 
 var (
 	// TODO: This should be runtime configurable, of course.
-	// Note: keys should be lower case
-	ApiKeyNames = map[string]bool{
+	// Note: keys should be lower case.
+	APIKeyNames = map[string]bool{
 		"key":     true, // Google
 		"api_key": true,
 	}
@@ -70,7 +70,7 @@ func updateSecurityDefinitionsFromOperation(sd spec.SecurityDefinitions, op *spe
 				scheme = spec.OAuth2AccessToken(authorizationURL, tknURL)
 			case APIKeyAuthSecurityDefinitionKey:
 				// Use random key since it is not specified
-				for key := range ApiKeyNames {
+				for key := range APIKeyNames {
 					scheme = spec.APIKeyAuth(key, apiKeyInHeader)
 					break
 				}


### PR DESCRIPTION
This PR provides some parsing of OAuth2 Bearer tokens to add the scopes within to the reconstructed API Spec. If the token doesn't look like a JWT, it reverts to the old behavior of simply adding an OAuth security label with no scopes.